### PR TITLE
Adding existing_cache_policy cloudfront variable for referencing exis…

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -53,6 +53,7 @@ locals {
       }, try(var.cloudfront.cache_policy.query_strings_config, {}))
     }
     origin_request_policy = try(var.cloudfront.origin_request_policy, null)
+    existing_cache_policy = try(var.cloudfront.existing_cache_policy, null)
 
     custom_waf                = var.cloudfront.custom_waf
     waf_logging_configuration = var.cloudfront.waf_logging_configuration

--- a/main.tf
+++ b/main.tf
@@ -233,6 +233,7 @@ module "cloudfront" {
   hsts                  = local.cloudfront.hsts
   cache_policy          = local.cloudfront.cache_policy
   remove_headers_config = local.cloudfront.remove_headers_config
+  existing_cache_policy = local.cloudfront.existing_cache_policy
 
   custom_waf                = local.cloudfront.custom_waf
   waf_logging_configuration = local.cloudfront.waf_logging_configuration

--- a/modules/opennext-cloudfront/cloudfront.tf
+++ b/modules/opennext-cloudfront/cloudfront.tf
@@ -2,6 +2,7 @@ locals {
   server_origin_id             = "${var.prefix}-server-origin"
   assets_origin_id             = "${var.prefix}-assets-origin"
   image_optimization_origin_id = "${var.prefix}-image-optimization-origin"
+  cloudfront_cache_policy_id   = var.existing_cache_policy == null ? aws_cloudfront_cache_policy.cache_policy[0].id : data.aws_cloudfront_cache_policy.cache_policy[0].id
 }
 
 resource "aws_cloudfront_function" "host_header_function" {
@@ -53,8 +54,15 @@ resource "aws_cloudfront_origin_request_policy" "origin_request_policy" {
   }
 }
 
+data "aws_cloudfront_cache_policy" "cache_policy" {
+  count = var.existing_cache_policy == null ? 0 : 1
+  name  = var.existing_cache_policy.name
+  id    = var.existing_cache_policy.id
+}
+
 resource "aws_cloudfront_cache_policy" "cache_policy" {
-  name = "${var.prefix}-cache-policy"
+  count = var.existing_cache_policy == null ? 1 : 0
+  name  = "${var.prefix}-cache-policy"
 
   default_ttl = var.cache_policy.default_ttl
   min_ttl     = var.cache_policy.min_ttl
@@ -237,7 +245,7 @@ resource "aws_cloudfront_distribution" "distribution" {
     target_origin_id = local.assets_origin_id
 
     response_headers_policy_id = aws_cloudfront_response_headers_policy.response_headers_policy.id
-    cache_policy_id            = aws_cloudfront_cache_policy.cache_policy.id
+    cache_policy_id            = local.cloudfront_cache_policy_id
     origin_request_policy_id = try(
       data.aws_cloudfront_origin_request_policy.origin_request_policy[0].id,
       aws_cloudfront_origin_request_policy.origin_request_policy[0].id
@@ -254,7 +262,7 @@ resource "aws_cloudfront_distribution" "distribution" {
     target_origin_id = local.image_optimization_origin_id
 
     response_headers_policy_id = aws_cloudfront_response_headers_policy.response_headers_policy.id
-    cache_policy_id            = aws_cloudfront_cache_policy.cache_policy.id
+    cache_policy_id            = local.cloudfront_cache_policy_id
     origin_request_policy_id = try(
       data.aws_cloudfront_origin_request_policy.origin_request_policy[0].id,
       aws_cloudfront_origin_request_policy.origin_request_policy[0].id
@@ -271,7 +279,7 @@ resource "aws_cloudfront_distribution" "distribution" {
     target_origin_id = local.server_origin_id
 
     response_headers_policy_id = aws_cloudfront_response_headers_policy.response_headers_policy.id
-    cache_policy_id            = aws_cloudfront_cache_policy.cache_policy.id
+    cache_policy_id            = local.cloudfront_cache_policy_id
     origin_request_policy_id = try(
       data.aws_cloudfront_origin_request_policy.origin_request_policy[0].id,
       aws_cloudfront_origin_request_policy.origin_request_policy[0].id
@@ -293,7 +301,7 @@ resource "aws_cloudfront_distribution" "distribution" {
     target_origin_id = local.server_origin_id
 
     response_headers_policy_id = aws_cloudfront_response_headers_policy.response_headers_policy.id
-    cache_policy_id            = aws_cloudfront_cache_policy.cache_policy.id
+    cache_policy_id            = local.cloudfront_cache_policy_id
     origin_request_policy_id = try(
       data.aws_cloudfront_origin_request_policy.origin_request_policy[0].id,
       aws_cloudfront_origin_request_policy.origin_request_policy[0].id
@@ -315,7 +323,7 @@ resource "aws_cloudfront_distribution" "distribution" {
     target_origin_id = local.assets_origin_id
 
     response_headers_policy_id = aws_cloudfront_response_headers_policy.response_headers_policy.id
-    cache_policy_id            = aws_cloudfront_cache_policy.cache_policy.id
+    cache_policy_id            = local.cloudfront_cache_policy_id
     origin_request_policy_id = try(
       data.aws_cloudfront_origin_request_policy.origin_request_policy[0].id,
       aws_cloudfront_origin_request_policy.origin_request_policy[0].id
@@ -335,7 +343,7 @@ resource "aws_cloudfront_distribution" "distribution" {
       target_origin_id = local.assets_origin_id
 
       response_headers_policy_id = aws_cloudfront_response_headers_policy.response_headers_policy.id
-      cache_policy_id            = aws_cloudfront_cache_policy.cache_policy.id
+      cache_policy_id            = local.cloudfront_cache_policy_id
       origin_request_policy_id = try(
         data.aws_cloudfront_origin_request_policy.origin_request_policy[0].id,
         aws_cloudfront_origin_request_policy.origin_request_policy[0].id
@@ -352,7 +360,7 @@ resource "aws_cloudfront_distribution" "distribution" {
     target_origin_id = local.server_origin_id
 
     response_headers_policy_id = aws_cloudfront_response_headers_policy.response_headers_policy.id
-    cache_policy_id            = aws_cloudfront_cache_policy.cache_policy.id
+    cache_policy_id            = local.cloudfront_cache_policy_id
     origin_request_policy_id = try(
       data.aws_cloudfront_origin_request_policy.origin_request_policy[0].id,
       aws_cloudfront_origin_request_policy.origin_request_policy[0].id

--- a/modules/opennext-cloudfront/variables.tf
+++ b/modules/opennext-cloudfront/variables.tf
@@ -196,3 +196,10 @@ variable "remove_headers_config" {
   })
 }
 
+variable "existing_cache_policy" {
+  description = "Details for data calling existing CloudFront cache policy"
+  type = object({
+    name = optional(string)
+    id   = optional(string)
+  })
+}

--- a/variables.tf
+++ b/variables.tf
@@ -389,6 +389,10 @@ variable "cloudfront" {
         items                 = optional(list(string))
       })
     }))
+    existing_cache_policy = optional(object({
+      name = optional(string)
+      id   = optional(string)
+    }))
     custom_waf = optional(object({
       arn = string
     }))


### PR DESCRIPTION
Adding existing_cache_policy cloudfront variable for referencing existing cache policy to use rather than creating new one.

<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This allows us to pass an existing_cache_policy inside the cloudfront configuration variable which will set the infrastructure to use an existing cache policy rather than creating one. 

## Context

This enables users to have multiple stacks using one cache policy which gets around the AWS hard limit of having 30 of these resources per account.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
