### PR TITLE
Use existing cloudfront policies

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -53,7 +53,9 @@ locals {
       }, try(var.cloudfront.cache_policy.query_strings_config, {}))
     }
     origin_request_policy = try(var.cloudfront.origin_request_policy, null)
-    existing_cache_policy = try(var.cloudfront.existing_cache_policy, null)
+    
+    existing_cache_policy            = try(var.cloudfront.existing_cache_policy, null)
+    existing_response_headers_policy = try(var.cloudfront.existing_response_headers_policy, null)
 
     custom_waf                = var.cloudfront.custom_waf
     waf_logging_configuration = var.cloudfront.waf_logging_configuration

--- a/locals.tf
+++ b/locals.tf
@@ -54,8 +54,8 @@ locals {
     }
     origin_request_policy = try(var.cloudfront.origin_request_policy, null)
     
-    existing_cache_policy            = try(var.cloudfront.existing_cache_policy, null)
-    existing_response_headers_policy = try(var.cloudfront.existing_response_headers_policy, null)
+    custom_cache_policy            = try(var.cloudfront.custom_cache_policy, null)
+    custom_response_headers_policy = try(var.cloudfront.custom_response_headers_policy, null)
 
     custom_waf                = var.cloudfront.custom_waf
     waf_logging_configuration = var.cloudfront.waf_logging_configuration

--- a/main.tf
+++ b/main.tf
@@ -233,7 +233,9 @@ module "cloudfront" {
   hsts                  = local.cloudfront.hsts
   cache_policy          = local.cloudfront.cache_policy
   remove_headers_config = local.cloudfront.remove_headers_config
-  existing_cache_policy = local.cloudfront.existing_cache_policy
+
+  existing_cache_policy            = local.cloudfront.existing_cache_policy
+  existing_response_headers_policy = local.cloudfront.existing_response_headers_policy
 
   custom_waf                = local.cloudfront.custom_waf
   waf_logging_configuration = local.cloudfront.waf_logging_configuration

--- a/main.tf
+++ b/main.tf
@@ -234,8 +234,8 @@ module "cloudfront" {
   cache_policy          = local.cloudfront.cache_policy
   remove_headers_config = local.cloudfront.remove_headers_config
 
-  existing_cache_policy            = local.cloudfront.existing_cache_policy
-  existing_response_headers_policy = local.cloudfront.existing_response_headers_policy
+  custom_cache_policy            = local.cloudfront.custom_cache_policy
+  custom_response_headers_policy = local.cloudfront.custom_response_headers_policy
 
   custom_waf                = local.cloudfront.custom_waf
   waf_logging_configuration = local.cloudfront.waf_logging_configuration

--- a/modules/opennext-cloudfront/cloudfront.tf
+++ b/modules/opennext-cloudfront/cloudfront.tf
@@ -2,7 +2,9 @@ locals {
   server_origin_id             = "${var.prefix}-server-origin"
   assets_origin_id             = "${var.prefix}-assets-origin"
   image_optimization_origin_id = "${var.prefix}-image-optimization-origin"
-  cloudfront_cache_policy_id   = var.existing_cache_policy == null ? aws_cloudfront_cache_policy.cache_policy[0].id : data.aws_cloudfront_cache_policy.cache_policy[0].id
+
+  cloudfront_cache_policy_id            = var.existing_cache_policy == null ? aws_cloudfront_cache_policy.cache_policy[0].id : data.aws_cloudfront_cache_policy.cache_policy[0].id
+  cloudfront_response_headers_policy_id = var.existing_response_headers_policy == null ? aws_cloudfront_response_headers_policy.response_headers_policy[0].id : data.aws_cloudfront_response_headers_policy.response_headers_policy[0].id
 }
 
 resource "aws_cloudfront_function" "host_header_function" {
@@ -109,7 +111,14 @@ resource "aws_cloudfront_cache_policy" "cache_policy" {
   }
 }
 
+data "aws_cloudfront_response_headers_policy" "response_headers_policy" {
+  count = var.existing_response_headers_policy == null ? 0 : 1
+  name  = var.existing_response_headers_policy.name
+  id    = var.existing_response_headers_policy.id
+}
+
 resource "aws_cloudfront_response_headers_policy" "response_headers_policy" {
+  count   = var.existing_response_headers_policy == null ? 1 : 0
   name    = "${var.prefix}-response-headers-policy"
   comment = "${var.prefix} Response Headers Policy"
 
@@ -244,7 +253,7 @@ resource "aws_cloudfront_distribution" "distribution" {
     cached_methods   = ["GET", "HEAD"]
     target_origin_id = local.assets_origin_id
 
-    response_headers_policy_id = aws_cloudfront_response_headers_policy.response_headers_policy.id
+    response_headers_policy_id = local.cloudfront_response_headers_policy_id
     cache_policy_id            = local.cloudfront_cache_policy_id
     origin_request_policy_id = try(
       data.aws_cloudfront_origin_request_policy.origin_request_policy[0].id,
@@ -261,7 +270,7 @@ resource "aws_cloudfront_distribution" "distribution" {
     cached_methods   = ["GET", "HEAD"]
     target_origin_id = local.image_optimization_origin_id
 
-    response_headers_policy_id = aws_cloudfront_response_headers_policy.response_headers_policy.id
+    response_headers_policy_id = local.cloudfront_response_headers_policy_id
     cache_policy_id            = local.cloudfront_cache_policy_id
     origin_request_policy_id = try(
       data.aws_cloudfront_origin_request_policy.origin_request_policy[0].id,
@@ -278,7 +287,7 @@ resource "aws_cloudfront_distribution" "distribution" {
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
     target_origin_id = local.server_origin_id
 
-    response_headers_policy_id = aws_cloudfront_response_headers_policy.response_headers_policy.id
+    response_headers_policy_id = local.cloudfront_response_headers_policy_id
     cache_policy_id            = local.cloudfront_cache_policy_id
     origin_request_policy_id = try(
       data.aws_cloudfront_origin_request_policy.origin_request_policy[0].id,
@@ -300,7 +309,7 @@ resource "aws_cloudfront_distribution" "distribution" {
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
     target_origin_id = local.server_origin_id
 
-    response_headers_policy_id = aws_cloudfront_response_headers_policy.response_headers_policy.id
+    response_headers_policy_id = local.cloudfront_response_headers_policy_id
     cache_policy_id            = local.cloudfront_cache_policy_id
     origin_request_policy_id = try(
       data.aws_cloudfront_origin_request_policy.origin_request_policy[0].id,
@@ -322,7 +331,7 @@ resource "aws_cloudfront_distribution" "distribution" {
     cached_methods   = ["GET", "HEAD"]
     target_origin_id = local.assets_origin_id
 
-    response_headers_policy_id = aws_cloudfront_response_headers_policy.response_headers_policy.id
+    response_headers_policy_id = local.cloudfront_response_headers_policy_id
     cache_policy_id            = local.cloudfront_cache_policy_id
     origin_request_policy_id = try(
       data.aws_cloudfront_origin_request_policy.origin_request_policy[0].id,
@@ -342,7 +351,7 @@ resource "aws_cloudfront_distribution" "distribution" {
       cached_methods   = ["GET", "HEAD", "OPTIONS"]
       target_origin_id = local.assets_origin_id
 
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.response_headers_policy.id
+      response_headers_policy_id = local.cloudfront_response_headers_policy_id
       cache_policy_id            = local.cloudfront_cache_policy_id
       origin_request_policy_id = try(
         data.aws_cloudfront_origin_request_policy.origin_request_policy[0].id,
@@ -359,7 +368,7 @@ resource "aws_cloudfront_distribution" "distribution" {
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
     target_origin_id = local.server_origin_id
 
-    response_headers_policy_id = aws_cloudfront_response_headers_policy.response_headers_policy.id
+    response_headers_policy_id = local.cloudfront_response_headers_policy_id
     cache_policy_id            = local.cloudfront_cache_policy_id
     origin_request_policy_id = try(
       data.aws_cloudfront_origin_request_policy.origin_request_policy[0].id,

--- a/modules/opennext-cloudfront/cloudfront.tf
+++ b/modules/opennext-cloudfront/cloudfront.tf
@@ -3,8 +3,8 @@ locals {
   assets_origin_id             = "${var.prefix}-assets-origin"
   image_optimization_origin_id = "${var.prefix}-image-optimization-origin"
 
-  cloudfront_cache_policy_id            = var.existing_cache_policy == null ? aws_cloudfront_cache_policy.cache_policy[0].id : data.aws_cloudfront_cache_policy.cache_policy[0].id
-  cloudfront_response_headers_policy_id = var.existing_response_headers_policy == null ? aws_cloudfront_response_headers_policy.response_headers_policy[0].id : data.aws_cloudfront_response_headers_policy.response_headers_policy[0].id
+  cloudfront_cache_policy_id            = var.custom_cache_policy == null ? aws_cloudfront_cache_policy.cache_policy[0].id : data.aws_cloudfront_cache_policy.cache_policy[0].id
+  cloudfront_response_headers_policy_id = var.custom_response_headers_policy == null ? aws_cloudfront_response_headers_policy.response_headers_policy[0].id : data.aws_cloudfront_response_headers_policy.response_headers_policy[0].id
 }
 
 resource "aws_cloudfront_function" "host_header_function" {
@@ -57,13 +57,13 @@ resource "aws_cloudfront_origin_request_policy" "origin_request_policy" {
 }
 
 data "aws_cloudfront_cache_policy" "cache_policy" {
-  count = var.existing_cache_policy == null ? 0 : 1
-  name  = var.existing_cache_policy.name
-  id    = var.existing_cache_policy.id
+  count = var.custom_cache_policy == null ? 0 : 1
+  name  = var.custom_cache_policy.name
+  id    = var.custom_cache_policy.id
 }
 
 resource "aws_cloudfront_cache_policy" "cache_policy" {
-  count = var.existing_cache_policy == null ? 1 : 0
+  count = var.custom_cache_policy == null ? 1 : 0
   name  = "${var.prefix}-cache-policy"
 
   default_ttl = var.cache_policy.default_ttl
@@ -112,13 +112,13 @@ resource "aws_cloudfront_cache_policy" "cache_policy" {
 }
 
 data "aws_cloudfront_response_headers_policy" "response_headers_policy" {
-  count = var.existing_response_headers_policy == null ? 0 : 1
-  name  = var.existing_response_headers_policy.name
-  id    = var.existing_response_headers_policy.id
+  count = var.custom_response_headers_policy == null ? 0 : 1
+  name  = var.custom_response_headers_policy.name
+  id    = var.custom_response_headers_policy.id
 }
 
 resource "aws_cloudfront_response_headers_policy" "response_headers_policy" {
-  count   = var.existing_response_headers_policy == null ? 1 : 0
+  count   = var.custom_response_headers_policy == null ? 1 : 0
   name    = "${var.prefix}-response-headers-policy"
   comment = "${var.prefix} Response Headers Policy"
 

--- a/modules/opennext-cloudfront/variables.tf
+++ b/modules/opennext-cloudfront/variables.tf
@@ -203,3 +203,11 @@ variable "existing_cache_policy" {
     id   = optional(string)
   })
 }
+
+variable "existing_response_headers_policy" {
+  description = "Details for data calling existing CloudFront response headers policy"
+  type = object({
+    name = optional(string)
+    id   = optional(string)
+  })
+}

--- a/modules/opennext-cloudfront/variables.tf
+++ b/modules/opennext-cloudfront/variables.tf
@@ -196,7 +196,7 @@ variable "remove_headers_config" {
   })
 }
 
-variable "existing_cache_policy" {
+variable "custom_cache_policy" {
   description = "Details for data calling existing CloudFront cache policy"
   type = object({
     name = optional(string)
@@ -204,7 +204,7 @@ variable "existing_cache_policy" {
   })
 }
 
-variable "existing_response_headers_policy" {
+variable "custom_response_headers_policy" {
   description = "Details for data calling existing CloudFront response headers policy"
   type = object({
     name = optional(string)

--- a/variables.tf
+++ b/variables.tf
@@ -393,6 +393,10 @@ variable "cloudfront" {
       name = optional(string)
       id   = optional(string)
     }))
+    existing_response_headers_policy = optional(object({
+      name = optional(string)
+      id   = optional(string)
+    }))
     custom_waf = optional(object({
       arn = string
     }))

--- a/variables.tf
+++ b/variables.tf
@@ -389,11 +389,11 @@ variable "cloudfront" {
         items                 = optional(list(string))
       })
     }))
-    existing_cache_policy = optional(object({
+    custom_cache_policy = optional(object({
       name = optional(string)
       id   = optional(string)
     }))
-    existing_response_headers_policy = optional(object({
+    custom_response_headers_policy = optional(object({
       name = optional(string)
       id   = optional(string)
     }))


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This allows us to pass a custom_response_headers_policy inside the cloudfront configuration variable which will set the infrastructure to use an existing response_headers policy rather than creating one.

It also renames the existing_cache_policy variable to custom_cache_policy to align these new variables with the custom_waf variable. 

## Context

This enables users to have multiple stacks using one response headers policy which gets around the AWS hard limit of having 30 of these resources per account.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
