### PR TITLE
Use existing kms keys

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -272,4 +272,11 @@ locals {
       }
     ], coalesce(try(var.warmer_options.iam_policy, null), []))
   }
+
+  /**
+   * CloudFront Log Options
+   **/
+  cloudfront_log_options = {
+    cloudwatch_log_group_kms_key_arn = try(var.cloudfront_log_options.cloudwatch_log_group_kms_key_arn, null)
+  }
 }

--- a/locals.tf
+++ b/locals.tf
@@ -225,6 +225,13 @@ locals {
   }
 
   /**
+   * ISR Revalidation Queue Options
+   **/
+  revalidation_queue_options = {
+    kms_key_arn = try(var.revalidation_queue_options.kms_key_arn, null)
+  }
+
+  /**
    * Warmer Function Options
    **/
   warmer_options = {

--- a/main.tf
+++ b/main.tf
@@ -150,6 +150,8 @@ module "revalidation_queue" {
 
   aws_account_id            = data.aws_caller_identity.current.account_id
   revalidation_function_arn = module.revalidation_function.lambda_function.arn
+
+  kms_key_arn = local.revalidation_queue_options.kms_key_arn
 }
 
 /**

--- a/main.tf
+++ b/main.tf
@@ -201,6 +201,8 @@ module "cloudfront_logs" {
   log_group_name  = "${var.prefix}-cloudfront-logs"
   log_bucket_name = "${var.prefix}-cloudfront-logs"
   retention       = 365
+
+  cloudwatch_log_group_kms_key_arn = local.cloudfront_log_options.cloudwatch_log_group_kms_key_arn
 }
 
 /**

--- a/variables.tf
+++ b/variables.tf
@@ -426,3 +426,11 @@ variable "cloudfront" {
     }))
   })
 }
+
+variable "cloudfront_log_options" {
+  description = "Variables passed to the cloudfront-logs module for the Next.js server"
+  type = object({
+    cloudwatch_log_group_kms_key_arn = optional(string)
+  })
+  default = {}
+}

--- a/variables.tf
+++ b/variables.tf
@@ -259,6 +259,14 @@ variable "revalidation_options" {
   default = {}
 }
 
+variable "revalidation_queue_options" {
+  description = "Variables passed to the opennext-revalidation-queue module for the ISR Revalidation Queue infrastructure"
+  type = object({
+    kms_key_arn = optional(string)
+  })
+  default = {}
+}
+
 variable "warmer_options" {
   description = "Variables passed to the opennext-lambda module for the Next.js Warmer function"
   type = object({
@@ -428,7 +436,7 @@ variable "cloudfront" {
 }
 
 variable "cloudfront_log_options" {
-  description = "Variables passed to the cloudfront-logs module for the Next.js server"
+  description = "Variables passed to the cloudfront-logs module for the CloudFront infrastructure"
   type = object({
     cloudwatch_log_group_kms_key_arn = optional(string)
   })


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This enables module users to configure their infrastructure to reuse existing KMS keys. The user can pass two new variable objects for the cloudfront log and revalidation queue infrastructure which would contain the KMS key ARNs to be used in the infrastructure. 

## Context

In some organisations there are restrictions on the creation and deletion of KMS keys and thus the creation and destruction of temporary environments can pose a challenge. 

These changes enable module users to pass KMS key ARNs of manually created or otherwise previously existing keys and use them in the infrastructure of their environments.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
