### PR TITLE
Adding coalesce function to pass through default subnet_map_public_ip…

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -91,7 +91,7 @@ locals {
 
     networking = {
       vpc_id                       = try(var.server_options.networking.vpc_id, null)
-      subnet_map_public_ip         = try(var.server_options.networking.subnet_map_public_ip, null)
+      subnet_map_public_ip         = coalesce(try(var.server_options.networking.subnet_map_public_ip, null), false)
       subnet_ids                   = coalesce(try(var.server_options.networking.subnet_ids, null), [])
       security_group_ingress_rules = coalesce(try(var.server_options.networking.sg_ingress_rules, null), [])
       security_group_egress_rules  = coalesce(try(var.server_options.networking.sg_egress_rules, null), [])
@@ -154,7 +154,7 @@ locals {
 
     networking = {
       vpc_id                       = try(var.image_optimization_options.networking.vpc_id, null)
-      subnet_map_public_ip         = try(var.image_optimization_options.networking.subnet_map_public_ip, null)
+      subnet_map_public_ip         = coalesce(try(var.image_optimization_options.networking.subnet_map_public_ip, null), false)
       subnet_ids                   = coalesce(try(var.image_optimization_options.networking.subnet_ids, null), [])
       security_group_ingress_rules = coalesce(try(var.image_optimization_options.networking.sg_ingress_rules, null), [])
       security_group_egress_rules  = coalesce(try(var.image_optimization_options.networking.sg_egress_rules, null), [])
@@ -205,7 +205,7 @@ locals {
 
     networking = {
       vpc_id                       = try(var.revalidation_options.networking.vpc_id, null)
-      subnet_map_public_ip         = try(var.revalidation_options.networking.subnet_map_public_ip, null)
+      subnet_map_public_ip         = coalesce(try(var.revalidation_options.networking.subnet_map_public_ip, null), false)
       subnet_ids                   = coalesce(try(var.revalidation_options.networking.subnet_ids, null), [])
       security_group_ingress_rules = coalesce(try(var.revalidation_options.networking.sg_ingress_rules, null), [])
       security_group_egress_rules  = coalesce(try(var.revalidation_options.networking.sg_egress_rules, null), [])
@@ -264,7 +264,7 @@ locals {
 
     networking = {
       vpc_id                       = try(var.warmer_options.networking.vpc_id, null)
-      subnet_map_public_ip         = try(var.warmer_options.networking.subnet_map_public_ip, null)
+      subnet_map_public_ip         = coalesce(try(var.warmer_options.networking.subnet_map_public_ip, null), false)
       subnet_ids                   = coalesce(try(var.warmer_options.networking.subnet_ids, null), [])
       security_group_ingress_rules = coalesce(try(var.warmer_options.networking.sg_ingress_rules, null), [])
       security_group_egress_rules  = coalesce(try(var.warmer_options.networking.sg_egress_rules, null), [])

--- a/modules/opennext-lambda/iam.tf
+++ b/modules/opennext-lambda/iam.tf
@@ -42,3 +42,9 @@ resource "aws_iam_role_policy_attachment" "lambda_policy_attachment" {
   role       = aws_iam_role.lambda_role.name
   policy_arn = aws_iam_policy.lambda_policy.arn
 }
+
+resource "aws_iam_role_policy_attachment" "aws_lambda_vpc_access" {
+  count      = var.vpc_id == null ? 0 : 1
+  role       = aws_iam_role.lambda_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+}


### PR DESCRIPTION
…, adding AWSLambdaVPCAccessExecutionRole to role if vpc_id not null.

<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Adding conditional lambda permissions and fixing how default values are passed to the module to fix pipeline errors when value is unset.

## Context

Fixes two more issues introduced in this version:
- Lambda permissions for associating VPC with the lambda are not present
- When subnet_map_public_ip is unset the build will fail with errors that the data call cannot contain null values

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
