### PR TITLE
Setting global required provider, passing providers to cloudfront child module, removing providers from child modules.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -5,6 +5,9 @@ terraform {
     aws = {
       source  = "hashicorp/aws"
       version = ">= 4.0"
+      configuration_aliases = [
+        aws.global,
+      ]
     }
   }
 }
@@ -216,6 +219,11 @@ module "cloudfront_logs" {
  **/
 module "cloudfront" {
   source       = "./modules/opennext-cloudfront"
+  providers = {
+    aws        = aws
+    aws.global = aws.global
+  }
+
   prefix       = "${var.prefix}-cloudfront"
   region       = local.aws_region
   default_tags = var.default_tags

--- a/modules/cloudfront-logs/main.tf
+++ b/modules/cloudfront-logs/main.tf
@@ -13,19 +13,3 @@ terraform {
     }
   }
 }
-
-provider "aws" {
-  region = var.region
-  default_tags {
-    tags = var.default_tags
-  }
-}
-
-provider "aws" {
-  alias  = "global"
-  region = "us-east-1"
-
-  default_tags {
-    tags = var.default_tags
-  }
-}

--- a/modules/opennext-assets/main.tf
+++ b/modules/opennext-assets/main.tf
@@ -8,10 +8,3 @@ terraform {
     }
   }
 }
-
-provider "aws" {
-  region = var.region
-  default_tags {
-    tags = var.default_tags
-  }
-}

--- a/modules/opennext-cloudfront/main.tf
+++ b/modules/opennext-cloudfront/main.tf
@@ -5,22 +5,9 @@ terraform {
     aws = {
       source  = "hashicorp/aws"
       version = ">= 4.0"
+      configuration_aliases = [
+        aws.global,
+      ]
     }
-  }
-}
-
-provider "aws" {
-  region = var.region
-  default_tags {
-    tags = var.default_tags
-  }
-}
-
-provider "aws" {
-  alias  = "global"
-  region = "us-east-1"
-
-  default_tags {
-    tags = var.default_tags
   }
 }

--- a/modules/opennext-lambda/main.tf
+++ b/modules/opennext-lambda/main.tf
@@ -12,10 +12,3 @@ terraform {
     }
   }
 }
-
-provider "aws" {
-  region = var.region
-  default_tags {
-    tags = var.default_tags
-  }
-}

--- a/modules/opennext-revalidation-queue/main.tf
+++ b/modules/opennext-revalidation-queue/main.tf
@@ -8,10 +8,3 @@ terraform {
     }
   }
 }
-
-provider "aws" {
-  region = var.region
-  default_tags {
-    tags = var.default_tags
-  }
-}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This fixes and improves how aws providers are passed between the main module and the child modules. This now means it's possible to pass an assume_role in the providers block which will get used across the child modules. 

## Context

Currently the child modules all setup their own providers instead of inheriting from the main module. This makes it impossible to pass assume_role blocks to the module. 

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
