### PR TITLE
Add new security headers to cloudfront

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -30,6 +30,21 @@ locals {
       override                   = true
       preload                    = true
     }, var.cloudfront.hsts)
+    content_security_policy = merge({
+      override = true
+      policy   = "default-src 'self'; img-src 'self' data:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self' data:"
+    }, var.cloudfront.content_security_policy)
+    content_type_options = merge({
+      override = true
+    }, var.cloudfront.content_type_options)
+    frame_options = merge({
+      override = true
+      option   = "DENY"
+    }, var.cloudfront.frame_options)
+    referrer_policy = merge({
+      override = true
+      policy   = "strict-origin-when-cross-origin"
+    }, var.cloudfront.referrer_policy)
     remove_headers_config = merge({
       items : []
     }, var.cloudfront.remove_headers_config)

--- a/locals.tf
+++ b/locals.tf
@@ -17,13 +17,13 @@ locals {
       locations        = []
     })
     price_class = coalesce(try(var.cloudfront.price_class, null), "PriceClass_All")
-    cors = merge({
-      allow_credentials = false,
-      allow_headers     = ["*"],
-      allow_methods     = ["ALL"],
-      allow_origins     = ["*"],
-      origin_override   = true
-    }, var.cloudfront.cors)
+    cors = {
+      allow_credentials = coalesce(var.cloudfront.cors.allow_credentials, false)
+      allow_headers     = coalesce(var.cloudfront.cors.allow_headers, ["*"])
+      allow_methods     = coalesce(var.cloudfront.cors.allow_methods, ["ALL"])
+      allow_origins     = coalesce(var.cloudfront.cors.allow_origins, ["*"])
+      origin_override   = coalesce(var.cloudfront.cors.origin_override, true)
+    }
     hsts = merge({
       access_control_max_age_sec = 31536000
       include_subdomains         = true

--- a/main.tf
+++ b/main.tf
@@ -240,15 +240,19 @@ module "cloudfront" {
     image_optimization_function = "${module.image_optimization_function.lambda_function_url.url_id}.lambda-url.${local.aws_region}.on.aws"
   }
 
-  aliases               = local.cloudfront.aliases
-  acm_certificate_arn   = local.cloudfront.acm_certificate_arn
-  assets_paths          = local.cloudfront.assets_paths
-  custom_headers        = local.cloudfront.custom_headers
-  geo_restriction       = local.cloudfront.geo_restriction
-  cors                  = local.cloudfront.cors
-  hsts                  = local.cloudfront.hsts
-  cache_policy          = local.cloudfront.cache_policy
-  remove_headers_config = local.cloudfront.remove_headers_config
+  aliases                 = local.cloudfront.aliases
+  acm_certificate_arn     = local.cloudfront.acm_certificate_arn
+  assets_paths            = local.cloudfront.assets_paths
+  custom_headers          = local.cloudfront.custom_headers
+  geo_restriction         = local.cloudfront.geo_restriction
+  cors                    = local.cloudfront.cors
+  hsts                    = local.cloudfront.hsts
+  content_security_policy = local.cloudfront.content_security_policy
+  content_type_options    = local.cloudfront.content_type_options
+  frame_options           = local.cloudfront.frame_options
+  referrer_policy         = local.cloudfront.referrer_policy
+  cache_policy            = local.cloudfront.cache_policy
+  remove_headers_config   = local.cloudfront.remove_headers_config
 
   custom_cache_policy            = local.cloudfront.custom_cache_policy
   custom_response_headers_policy = local.cloudfront.custom_response_headers_policy

--- a/modules/opennext-cloudfront/cloudfront.tf
+++ b/modules/opennext-cloudfront/cloudfront.tf
@@ -140,6 +140,25 @@ resource "aws_cloudfront_response_headers_policy" "response_headers_policy" {
   }
 
   security_headers_config {
+    content_security_policy {
+      override                = var.content_security_policy.override
+      content_security_policy = var.content_security_policy.policy
+    }
+
+    content_type_options {
+      override = var.content_type_options.override
+    }
+
+    frame_options {
+      override     = var.frame_options.override
+      frame_option = var.frame_options.option
+    }
+
+    referrer_policy {
+      override        = var.referrer_policy.override
+      referrer_policy = var.referrer_policy.policy
+    }
+
     strict_transport_security {
       access_control_max_age_sec = var.hsts.access_control_max_age_sec
       include_subdomains         = var.hsts.include_subdomains

--- a/modules/opennext-cloudfront/variables.tf
+++ b/modules/opennext-cloudfront/variables.tf
@@ -104,6 +104,52 @@ variable "hsts" {
   }
 }
 
+variable "content_security_policy" {
+  description = "Content-Security-Policy security header configuration for the CloudFront distribution"
+  type = object({
+    override = bool
+    policy   = string
+  })
+  default = {
+    override = true
+    policy   = "default-src 'self'; img-src 'self' data:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self' data:"
+  }
+}
+
+variable "content_type_options" {
+  description = "X-Content-Type-Options security header configuration for the CloudFront distribution"
+  type = object({
+    override = bool
+  })
+  default = {
+    override = true
+  }
+}
+
+variable "frame_options" {
+  description = "X-Frame-Options security header configuration for the CloudFront distribution"
+  type = object({
+    override = bool
+    option   = string
+  })
+  default = {
+    override = true
+    option   = "DENY"
+  }
+}
+
+variable "referrer_policy" {
+  description = "Referrer-Policy security header configuration for the CloudFront distribution"
+  type = object({
+    override = bool
+    policy   = string
+  })
+  default = {
+    override = true
+    policy   = "strict-origin-when-cross-origin"
+  }
+}
+
 variable "custom_waf" {
   description = "ARN value for an externally created AWS WAF"
   type = object({

--- a/variables.tf
+++ b/variables.tf
@@ -369,6 +369,21 @@ variable "cloudfront" {
       override                   = bool
       preload                    = bool
     }))
+    content_security_policy = optional(object({
+      override = bool
+      policy   = string
+    }))
+    content_type_options = optional(object({
+      override = bool
+    }))
+    frame_options = optional(object({
+      override = bool
+      option   = string
+    }))
+    referrer_policy = optional(object({
+      override = bool
+      policy   = string
+    }))
     cache_policy = optional(object({
       default_ttl                   = optional(number)
       min_ttl                       = optional(number)

--- a/variables.tf
+++ b/variables.tf
@@ -354,11 +354,11 @@ variable "cloudfront" {
       locations        = list(string)
     }))
     cors = optional(object({
-      allow_credentials = bool,
-      allow_headers     = list(string)
-      allow_methods     = list(string)
-      allow_origins     = list(string)
-      origin_override   = bool
+      allow_credentials = optional(bool)
+      allow_headers     = optional(list(string))
+      allow_methods     = optional(list(string))
+      allow_origins     = optional(list(string))
+      origin_override   = optional(bool)
     }))
     remove_headers_config = optional(object({
       items = list(string)


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Adding new headers to cloudfront as default:
- Content-Security-Policy
- Referrer-Policy
- X-Content-Type-Options
- X-Frame-Options

## Context

This is an improvement after pen testing tools found these best practice headers missing from requests to sites using this infrastructure

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
