### PR TITLE
Setting most secure content security policy

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -32,7 +32,7 @@ locals {
     }
     content_security_policy = {
       override = coalesce(try(var.cloudfront.content_security_policy.override, null), true)
-      policy   = coalesce(try(var.cloudfront.content_security_policy.policy, null), "default-src 'self'; img-src 'self' data:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self' data:")
+      policy   = coalesce(try(var.cloudfront.content_security_policy.policy, null), "default-src 'self'")
     }
     content_type_options = {
       override = coalesce(try(var.cloudfront.content_type_options.override, null), true)

--- a/locals.tf
+++ b/locals.tf
@@ -31,17 +31,21 @@ locals {
       preload                    = coalesce(try(var.cloudfront.hsts.preload, null), true)
     }
     content_security_policy = {
+      enabled  = coalesce(try(var.cloudfront.content_security_policy.enabled, null), false)
       override = coalesce(try(var.cloudfront.content_security_policy.override, null), true)
       policy   = coalesce(try(var.cloudfront.content_security_policy.policy, null), "default-src 'self'")
     }
     content_type_options = {
+      enabled  = coalesce(try(var.cloudfront.content_type_options.enabled, null), true)
       override = coalesce(try(var.cloudfront.content_type_options.override, null), true)
     }
     frame_options = {
+      enabled  = coalesce(try(var.cloudfront.frame_options.enabled, null), true)
       override = coalesce(try(var.cloudfront.frame_options.override, null), true)
-      option   = coalesce(try(var.cloudfront.frame_options.option, null), "DENY")
+      option   = coalesce(try(var.cloudfront.frame_options.option, null), "SAMEORIGIN")
     }
     referrer_policy = {
+      enabled  = coalesce(try(var.cloudfront.referrer_policy.enabled, null), true)
       override = coalesce(try(var.cloudfront.referrer_policy.override, null), true)
       policy   = coalesce(try(var.cloudfront.referrer_policy.policy, null), "strict-origin-when-cross-origin")
     }

--- a/modules/opennext-cloudfront/cloudfront.tf
+++ b/modules/opennext-cloudfront/cloudfront.tf
@@ -140,23 +140,35 @@ resource "aws_cloudfront_response_headers_policy" "response_headers_policy" {
   }
 
   security_headers_config {
-    content_security_policy {
-      override                = var.content_security_policy.override
-      content_security_policy = var.content_security_policy.policy
+    dynamic "content_security_policy" {
+      for_each = var.content_security_policy.enabled ? [1] : []
+      content {
+        override                = var.content_security_policy.override
+        content_security_policy = var.content_security_policy.policy
+      }
     }
 
-    content_type_options {
-      override = var.content_type_options.override
+    dynamic "content_type_options" {
+      for_each = var.content_type_options.enabled ? [1] : []
+      content {
+        override = var.content_type_options.override
+      }
     }
 
-    frame_options {
-      override     = var.frame_options.override
-      frame_option = var.frame_options.option
+    dynamic "frame_options" {
+      for_each = var.frame_options.enabled ? [1] : []
+      content {
+        override     = var.frame_options.override
+        frame_option = var.frame_options.option
+      }
     }
 
-    referrer_policy {
-      override        = var.referrer_policy.override
-      referrer_policy = var.referrer_policy.policy
+    dynamic "referrer_policy" {
+      for_each = var.referrer_policy.enabled ? [1] : []
+      content {
+        override        = var.referrer_policy.override
+        referrer_policy = var.referrer_policy.policy
+      }
     }
 
     strict_transport_security {

--- a/modules/opennext-cloudfront/variables.tf
+++ b/modules/opennext-cloudfront/variables.tf
@@ -107,10 +107,12 @@ variable "hsts" {
 variable "content_security_policy" {
   description = "Content-Security-Policy security header configuration for the CloudFront distribution"
   type = object({
+    enabled  = bool
     override = bool
     policy   = string
   })
   default = {
+    enabled  = false
     override = true
     policy   = "default-src 'self'"
   }
@@ -119,9 +121,11 @@ variable "content_security_policy" {
 variable "content_type_options" {
   description = "X-Content-Type-Options security header configuration for the CloudFront distribution"
   type = object({
+    enabled  = bool
     override = bool
   })
   default = {
+    enabled  = false
     override = true
   }
 }
@@ -129,22 +133,26 @@ variable "content_type_options" {
 variable "frame_options" {
   description = "X-Frame-Options security header configuration for the CloudFront distribution"
   type = object({
+    enabled  = bool
     override = bool
     option   = string
   })
   default = {
+    enabled  = false
     override = true
-    option   = "DENY"
+    option   = "SAMEORIGIN"
   }
 }
 
 variable "referrer_policy" {
   description = "Referrer-Policy security header configuration for the CloudFront distribution"
   type = object({
+    enabled  = bool
     override = bool
     policy   = string
   })
   default = {
+    enabled  = false
     override = true
     policy   = "strict-origin-when-cross-origin"
   }

--- a/modules/opennext-cloudfront/variables.tf
+++ b/modules/opennext-cloudfront/variables.tf
@@ -112,7 +112,7 @@ variable "content_security_policy" {
   })
   default = {
     override = true
-    policy   = "default-src 'self'; img-src 'self' data:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self' data:"
+    policy   = "default-src 'self'"
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -370,17 +370,21 @@ variable "cloudfront" {
       preload                    = optional(bool)
     }))
     content_security_policy = optional(object({
+      enabled  = optional(bool)
       override = optional(bool)
       policy   = optional(string)
     }))
     content_type_options = optional(object({
+      enabled  = optional(bool)
       override = optional(bool)
     }))
     frame_options = optional(object({
+      enabled  = optional(bool)
       override = optional(bool)
       option   = optional(string)
     }))
     referrer_policy = optional(object({
+      enabled  = optional(bool)
       override = optional(bool)
       policy   = optional(string)
     }))


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Setting better defaults for security headers such that non-intrusive ones are added by default but content security policy is disabled by default. Setting best practice defaults for each security header to be minimally disruptive while having a very restrictive default for the content security policy as that should be fine tuned to the users needs. 

## Context

<!-- Why is this change required? What problem does it solve? -->

This is required to make this module as secure as possible while making it easy to use with sensible defaults. Currently the content security policy is pretty insecure and automatically applied but it's not possible to turn it off, so this change now sets it off by default but enables users to turn it on and configure it safely for their site. 

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
