### PR TITLE
Setting reserved_concurrency to -1 across the module.

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -99,7 +99,7 @@ locals {
       timeout                        = coalesce(try(var.server_options.function.timeout, null), 30)
       publish                        = coalesce(try(var.server_options.function.publish, null), false)
       dead_letter_config             = try(var.server_options.function.dead_letter_config, null)
-      reserved_concurrent_executions = coalesce(try(var.server_options.function.reserved_concurrent_executions, null), 10)
+      reserved_concurrent_executions = coalesce(try(var.server_options.function.reserved_concurrent_executions, null), -1)
       code_signing_config            = try(var.server_options.function.code_signing_config, null)
     }
 
@@ -162,7 +162,7 @@ locals {
       timeout                        = coalesce(try(var.image_optimization_options.function.timeout, null), 30)
       publish                        = coalesce(try(var.image_optimization_options.function.publish, null), false)
       dead_letter_config             = try(var.image_optimization_options.function.dead_letter_config, null)
-      reserved_concurrent_executions = coalesce(try(var.image_optimization_options.function.reserved_concurrent_executions, null), 3)
+      reserved_concurrent_executions = coalesce(try(var.image_optimization_options.function.reserved_concurrent_executions, null), -1)
       code_signing_config            = try(var.image_optimization_options.function.code_signing_config, null)
     }
 
@@ -213,7 +213,7 @@ locals {
       timeout                        = coalesce(try(var.revalidation_options.function.timeout, null), 30)
       publish                        = coalesce(try(var.revalidation_options.function.publish, null), false)
       dead_letter_config             = try(var.revalidation_options.function.dead_letter_config, null)
-      reserved_concurrent_executions = coalesce(try(var.revalidation_options.function.reserved_concurrent_executions, null), 3)
+      reserved_concurrent_executions = coalesce(try(var.revalidation_options.function.reserved_concurrent_executions, null), -1)
       code_signing_config            = try(var.revalidation_options.function.code_signing_config, null)
     }
 
@@ -272,7 +272,7 @@ locals {
       timeout                        = coalesce(try(var.warmer_options.function.timeout, null), 30)
       publish                        = coalesce(try(var.warmer_options.function.publish, null), false)
       dead_letter_config             = try(var.warmer_options.function.dead_letter_config, null)
-      reserved_concurrent_executions = coalesce(try(var.warmer_options.function.reserved_concurrent_executions, null), 3)
+      reserved_concurrent_executions = coalesce(try(var.warmer_options.function.reserved_concurrent_executions, null), -1)
       code_signing_config            = try(var.warmer_options.function.code_signing_config, null)
     }
 

--- a/modules/cloudfront-logs/lambda.tf
+++ b/modules/cloudfront-logs/lambda.tf
@@ -23,7 +23,7 @@ resource "aws_lambda_function" "cloudfront_logs_function" {
   handler = "index.handler"
 
   timeout                        = 5
-  reserved_concurrent_executions = 3
+  reserved_concurrent_executions = -1
 
   filename                = data.archive_file.cloudfront_logs_zip.output_path
   source_code_hash        = data.archive_file.cloudfront_logs_zip.output_base64sha256

--- a/modules/opennext-lambda/variables.tf
+++ b/modules/opennext-lambda/variables.tf
@@ -132,7 +132,7 @@ variable "dead_letter_config" {
 variable "reserved_concurrent_executions" {
   description = "Concurrency limit for the lambda function"
   type        = number
-  default     = 10
+  default     = -1
 }
 
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Setting reserved concurrency to -1 to disable and use unreserved account concurrency by default.

## Context

Currently we use a reserved concurrency of 10 for the server lambda and 3 for other lambda functions. This default results in discreet site performance issues due to throttling as well as verbose changes needed to unset the reserved concurrency values across the different lambda functions. 

It's understandable that the original authors set these values to protect the users from expensive bills, however the performance issues are an equally problematic and more likely scenario faced by users of the module. 

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
