### PR TITLE
Adding filter paramters to log_group objects in module variables.

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -127,8 +127,10 @@ variable "server_options" {
       })))
     }))
     log_group = optional(object({
-      retention_in_days = optional(number)
-      kms_key_id        = optional(string)
+      retention_in_days      = optional(number)
+      kms_key_id             = optional(string)
+      filter_destination_arn = optional(string)
+      filter_pattern         = optional(string)
     }))
   })
   default = {}
@@ -194,8 +196,10 @@ variable "image_optimization_options" {
       })))
     }))
     log_group = optional(object({
-      retention_in_days = optional(number)
-      kms_key_id        = optional(string)
+      retention_in_days      = optional(number)
+      kms_key_id             = optional(string)
+      filter_destination_arn = optional(string)
+      filter_pattern         = optional(string)
     }))
   })
   default = {}
@@ -261,8 +265,10 @@ variable "revalidation_options" {
       })))
     }))
     log_group = optional(object({
-      retention_in_days = optional(number)
-      kms_key_id        = optional(string)
+      retention_in_days      = optional(number)
+      kms_key_id             = optional(string)
+      filter_destination_arn = optional(string)
+      filter_pattern         = optional(string)
     }))
   })
   default = {}
@@ -336,8 +342,10 @@ variable "warmer_options" {
       })))
     }))
     log_group = optional(object({
-      retention_in_days = optional(number)
-      kms_key_id        = optional(string)
+      retention_in_days      = optional(number)
+      kms_key_id             = optional(string)
+      filter_destination_arn = optional(string)
+      filter_pattern         = optional(string)
     }))
   })
   default = {}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This fixes / extends a previous change where we added filter parameters within the modules but failed to include them in the variables.tf file. 

## Context

We just merged a change to pass filter parameters to individual lambda module invocations, but failed to add them to the variables so that users can override the values to trigger the creation of the log subscription filter.  

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
