### PR TITLE
Setting the locals filter_pattern to return empty string instead of n…

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -107,7 +107,7 @@ locals {
       retention_in_days      = coalesce(try(var.server_options.log_group.retention_in_days, null), 365)
       kms_key_id             = try(var.server_options.log_group.kms_key_id, null)
       filter_destination_arn = try(var.server_options.log_group.filter_destination_arn, null)
-      filter_pattern         = coalesce(try(var.server_options.log_group.filter_pattern, null), "")
+      filter_pattern         = try(var.server_options.log_group.filter_pattern, "")
     }
 
     networking = {
@@ -172,7 +172,7 @@ locals {
       retention_in_days      = coalesce(try(var.image_optimization_options.log_group.retention_in_days, null), 365)
       kms_key_id             = try(var.image_optimization_options.log_group.kms_key_id, null)
       filter_destination_arn = try(var.image_optimization_options.log_group.filter_destination_arn, null)
-      filter_pattern         = coalesce(try(var.image_optimization_options.log_group.filter_pattern, null), "")
+      filter_pattern         = try(var.image_optimization_options.log_group.filter_pattern, "")
     }
 
     networking = {
@@ -225,7 +225,7 @@ locals {
       retention_in_days      = coalesce(try(var.revalidation_options.log_group.retention_in_days, null), 365)
       kms_key_id             = try(var.revalidation_options.log_group.kms_key_id, null)
       filter_destination_arn = try(var.revalidation_options.log_group.filter_destination_arn, null)
-      filter_pattern         = coalesce(try(var.revalidation_options.log_group.filter_pattern, null), "")
+      filter_pattern         = try(var.revalidation_options.log_group.filter_pattern, "")
     }
 
     networking = {
@@ -286,7 +286,7 @@ locals {
       retention_in_days      = coalesce(try(var.warmer_options.log_group.retention_in_days, null), 365)
       kms_key_id             = try(var.warmer_options.log_group.kms_key_id, null)
       filter_destination_arn = try(var.warmer_options.log_group.filter_destination_arn, null)
-      filter_pattern         = coalesce(try(var.warmer_options.log_group.filter_pattern, null), "")
+      filter_pattern         = try(var.warmer_options.log_group.filter_pattern, "")
     }
 
     networking = {


### PR DESCRIPTION
…ull when no value is given.

<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This is a quick fix for when no value is passed for the filter_pattern parameter, setting a default value of empty string.

## Context

Currently when no filter_pattern is passed, we do a coalesce to try to select the first non-null value, however it treats an empty string and null-like and so fails. This causes the plans to fail when no value is passed. 

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
