### PR TITLE
Adding Cloudfront origin access control object, enabling Cloudfront t…

### DIFF
--- a/modules/opennext-cloudfront/cloudfront.tf
+++ b/modules/opennext-cloudfront/cloudfront.tf
@@ -7,6 +7,14 @@ locals {
   cloudfront_response_headers_policy_id = var.custom_response_headers_policy == null ? aws_cloudfront_response_headers_policy.response_headers_policy[0].id : data.aws_cloudfront_response_headers_policy.response_headers_policy[0].id
 }
 
+resource "aws_cloudfront_origin_access_control" "lambda_oac" {
+  name                              = "${var.prefix}-lambda-oac"
+  description                       = "OAC for Lambda Function URL origins"
+  origin_access_control_origin_type = "lambda"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
 resource "aws_cloudfront_function" "host_header_function" {
   name    = "${var.prefix}-preserve-host"
   runtime = "cloudfront-js-1.0"
@@ -261,6 +269,8 @@ resource "aws_cloudfront_distribution" "distribution" {
       origin_protocol_policy = "https-only"
       origin_ssl_protocols   = ["TLSv1.2"]
     }
+
+    origin_access_control_id = aws_cloudfront_origin_access_control.lambda_oac.id
   }
 
   # Image Optimization Function Origin
@@ -275,6 +285,8 @@ resource "aws_cloudfront_distribution" "distribution" {
       origin_protocol_policy = "https-only"
       origin_ssl_protocols   = ["TLSv1.2"]
     }
+
+    origin_access_control_id = aws_cloudfront_origin_access_control.lambda_oac.id
   }
 
   # Behaviour - Hashed Static Files (/_next/static/*)

--- a/modules/opennext-lambda/lambda.tf
+++ b/modules/opennext-lambda/lambda.tf
@@ -71,11 +71,8 @@ resource "aws_lambda_function" "function" {
 }
 
 resource "aws_lambda_function_url" "function_url" {
-  # TODO: Find a way to authenticate lambda function with CloudFront
-  # checkov:skip=CKV_AWS_258:Lambda Function URL is public for CloudFront origin
-
   function_name      = aws_lambda_function.function.function_name
-  authorization_type = "NONE"
+  authorization_type = "AWS_IAM"
   invoke_mode        = "BUFFERED"
 }
 
@@ -83,7 +80,7 @@ resource "aws_lambda_permission" "function_url_permission" {
   action                 = "lambda:InvokeFunctionUrl"
   function_name          = aws_lambda_function.function.function_name
   principal              = "cloudfront.amazonaws.com"
-  function_url_auth_type = "NONE"
+  function_url_auth_type = "AWS_IAM"
 }
 
 resource "aws_security_group" "function_sg" {


### PR DESCRIPTION
…o hit lambda funtion url with AWS_IAM auth type.

<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This change adds AWS_IAM auth on the function URLs and sets up a Cloudfront origin access identity such that Cloudfront can hit these function URLs.  

## Context

Currently anyone can hit the lambda function URLs from anywhere, which is considered a security risk. This change adds AWS_IAM auth on the function URLs which resolves the security issue as these function URLs will not longer be accessible from the internet. 

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [x] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
