### PR TITLE
Fixing WAF logging filter label name condition and redacted fields te…

### DIFF
--- a/modules/opennext-cloudfront/waf.tf
+++ b/modules/opennext-cloudfront/waf.tf
@@ -151,7 +151,7 @@ resource "aws_wafv2_web_acl_logging_configuration" "waf_logging" {
           }
 
           dynamic "condition" {
-            for_each = filter.value.label_name_condition != null ? toset(filter.label_name_condition) : []
+            for_each = filter.value.label_name_condition != null ? toset(filter.value.label_name_condition) : []
 
             content {
               label_name_condition {
@@ -165,7 +165,7 @@ resource "aws_wafv2_web_acl_logging_configuration" "waf_logging" {
   }
 
   dynamic "redacted_fields" {
-    for_each = var.waf_logging_configuration.redacted_fields == null ? toset(var.waf_logging_configuration.redacted_fields) : []
+    for_each = var.waf_logging_configuration.redacted_fields != null ? toset(var.waf_logging_configuration.redacted_fields) : []
 
     content {
       dynamic "method" {


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This change fixes two bugs in how the CloudFront WAF logging configuration works.

## Context

When custom_waf is null and waf_logging_configuration only has a log_destination_configs list passed, the build fails due to a broken ternary operator.

This fixes that problem and one with the filter label name condition.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
