### PR TITLE
Creating origin_read_timeout to enable the passing of longer timeout.

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -72,6 +72,7 @@ locals {
       }, try(var.cloudfront.cache_policy.query_strings_config, {}))
     }
     origin_request_policy = try(var.cloudfront.origin_request_policy, null)
+    origin_read_timeout   = try(var.cloudfront.origin_read_timeout, null)
     
     custom_cache_policy            = try(var.cloudfront.custom_cache_policy, null)
     custom_response_headers_policy = try(var.cloudfront.custom_response_headers_policy, null)

--- a/main.tf
+++ b/main.tf
@@ -267,6 +267,7 @@ module "cloudfront" {
   referrer_policy         = local.cloudfront.referrer_policy
   cache_policy            = local.cloudfront.cache_policy
   remove_headers_config   = local.cloudfront.remove_headers_config
+  origin_read_timeout     = local.cloudfront.origin_read_timeout
 
   custom_cache_policy            = local.cloudfront.custom_cache_policy
   custom_response_headers_policy = local.cloudfront.custom_response_headers_policy

--- a/modules/opennext-cloudfront/cloudfront.tf
+++ b/modules/opennext-cloudfront/cloudfront.tf
@@ -268,6 +268,7 @@ resource "aws_cloudfront_distribution" "distribution" {
       https_port             = 443
       origin_protocol_policy = "https-only"
       origin_ssl_protocols   = ["TLSv1.2"]
+      origin_read_timeout    = var.origin_read_timeout
     }
 
     origin_access_control_id = aws_cloudfront_origin_access_control.lambda_oac.id
@@ -284,6 +285,7 @@ resource "aws_cloudfront_distribution" "distribution" {
       https_port             = 443
       origin_protocol_policy = "https-only"
       origin_ssl_protocols   = ["TLSv1.2"]
+      origin_read_timeout    = var.origin_read_timeout
     }
 
     origin_access_control_id = aws_cloudfront_origin_access_control.lambda_oac.id

--- a/modules/opennext-cloudfront/variables.tf
+++ b/modules/opennext-cloudfront/variables.tf
@@ -19,6 +19,11 @@ variable "comment" {
   description = "Comment to add to the CloudFront distribution"
 }
 
+variable "origin_read_timeout" {
+  type        = string
+  description = "The read timeout for the origin"
+}
+
 variable "acm_certificate_arn" {
   type = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -356,6 +356,7 @@ variable "cloudfront" {
     aliases             = list(string)
     acm_certificate_arn = string
     comment             = optional(string)
+    origin_read_timeout = optional(string)
     assets_paths        = optional(list(string))
     custom_headers = optional(list(object({
       header   = string


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This enables users to pass a longer Cloudfront origin read timeout to the 

## Context

Currently if a NextJS site using this module makes a call to the server origin that takes more than 30 seconds, it throws an error. Users may want to extend this timeout to the maximum of 120 seconds to get around challenging to fix problems, or generally give longer windows for server lambdas requests to complete. 

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
