### PR TITLE
Passing specific s3 origin request managed policy to assets origin be…

### DIFF
--- a/modules/opennext-cloudfront/cloudfront.tf
+++ b/modules/opennext-cloudfront/cloudfront.tf
@@ -3,8 +3,10 @@ locals {
   assets_origin_id             = "${var.prefix}-assets-origin"
   image_optimization_origin_id = "${var.prefix}-image-optimization-origin"
 
-  cloudfront_cache_policy_id            = var.custom_cache_policy == null ? aws_cloudfront_cache_policy.cache_policy[0].id : data.aws_cloudfront_cache_policy.cache_policy[0].id
-  cloudfront_response_headers_policy_id = var.custom_response_headers_policy == null ? aws_cloudfront_response_headers_policy.response_headers_policy[0].id : data.aws_cloudfront_response_headers_policy.response_headers_policy[0].id
+  cloudfront_cache_policy_id             = var.custom_cache_policy == null ? aws_cloudfront_cache_policy.cache_policy[0].id : data.aws_cloudfront_cache_policy.cache_policy[0].id
+  cloudfront_response_headers_policy_id  = var.custom_response_headers_policy == null ? aws_cloudfront_response_headers_policy.response_headers_policy[0].id : data.aws_cloudfront_response_headers_policy.response_headers_policy[0].id
+  cloudfront_origin_request_policy_id    = var.origin_request_policy == null ? aws_cloudfront_origin_request_policy.origin_request_policy[0].id : data.aws_cloudfront_origin_request_policy.origin_request_policy[0].id
+  cloudfront_s3_origin_request_policy_id = var.origin_request_policy == null ? aws_cloudfront_origin_request_policy.origin_request_policy[0].id : data.aws_cloudfront_origin_request_policy.s3_origin_request_policy[0].id
 }
 
 resource "aws_cloudfront_function" "host_header_function" {
@@ -24,6 +26,11 @@ EOF
 data "aws_cloudfront_origin_request_policy" "origin_request_policy" {
   count = var.origin_request_policy == null ? 1 : 0
   name  = "Managed-AllViewerExceptHostHeader"
+}
+
+data "aws_cloudfront_origin_request_policy" "s3_origin_request_policy" {
+  count = var.origin_request_policy == null ? 1 : 0
+  name  = "CORS-S3Origin"
 }
 
 resource "aws_cloudfront_origin_request_policy" "origin_request_policy" {
@@ -288,10 +295,7 @@ resource "aws_cloudfront_distribution" "distribution" {
 
     response_headers_policy_id = local.cloudfront_response_headers_policy_id
     cache_policy_id            = local.cloudfront_cache_policy_id
-    origin_request_policy_id = try(
-      data.aws_cloudfront_origin_request_policy.origin_request_policy[0].id,
-      aws_cloudfront_origin_request_policy.origin_request_policy[0].id
-    )
+    origin_request_policy_id   = local.cloudfront_s3_origin_request_policy_id
 
     compress               = true
     viewer_protocol_policy = "redirect-to-https"
@@ -305,10 +309,7 @@ resource "aws_cloudfront_distribution" "distribution" {
 
     response_headers_policy_id = local.cloudfront_response_headers_policy_id
     cache_policy_id            = local.cloudfront_cache_policy_id
-    origin_request_policy_id = try(
-      data.aws_cloudfront_origin_request_policy.origin_request_policy[0].id,
-      aws_cloudfront_origin_request_policy.origin_request_policy[0].id
-    )
+    origin_request_policy_id   = local.cloudfront_origin_request_policy_id
 
     compress               = true
     viewer_protocol_policy = "redirect-to-https"
@@ -322,10 +323,7 @@ resource "aws_cloudfront_distribution" "distribution" {
 
     response_headers_policy_id = local.cloudfront_response_headers_policy_id
     cache_policy_id            = local.cloudfront_cache_policy_id
-    origin_request_policy_id = try(
-      data.aws_cloudfront_origin_request_policy.origin_request_policy[0].id,
-      aws_cloudfront_origin_request_policy.origin_request_policy[0].id
-    )
+    origin_request_policy_id   = local.cloudfront_origin_request_policy_id
 
     compress               = true
     viewer_protocol_policy = "redirect-to-https"
@@ -344,10 +342,7 @@ resource "aws_cloudfront_distribution" "distribution" {
 
     response_headers_policy_id = local.cloudfront_response_headers_policy_id
     cache_policy_id            = local.cloudfront_cache_policy_id
-    origin_request_policy_id = try(
-      data.aws_cloudfront_origin_request_policy.origin_request_policy[0].id,
-      aws_cloudfront_origin_request_policy.origin_request_policy[0].id
-    )
+    origin_request_policy_id   = local.cloudfront_origin_request_policy_id
 
     compress               = true
     viewer_protocol_policy = "redirect-to-https"
@@ -366,10 +361,7 @@ resource "aws_cloudfront_distribution" "distribution" {
 
     response_headers_policy_id = local.cloudfront_response_headers_policy_id
     cache_policy_id            = local.cloudfront_cache_policy_id
-    origin_request_policy_id = try(
-      data.aws_cloudfront_origin_request_policy.origin_request_policy[0].id,
-      aws_cloudfront_origin_request_policy.origin_request_policy[0].id
-    )
+    origin_request_policy_id   = local.cloudfront_s3_origin_request_policy_id
 
     compress               = true
     viewer_protocol_policy = "redirect-to-https"
@@ -386,10 +378,7 @@ resource "aws_cloudfront_distribution" "distribution" {
 
       response_headers_policy_id = local.cloudfront_response_headers_policy_id
       cache_policy_id            = local.cloudfront_cache_policy_id
-      origin_request_policy_id = try(
-        data.aws_cloudfront_origin_request_policy.origin_request_policy[0].id,
-        aws_cloudfront_origin_request_policy.origin_request_policy[0].id
-      )
+      origin_request_policy_id   = local.cloudfront_s3_origin_request_policy_id
 
       compress               = true
       viewer_protocol_policy = "redirect-to-https"
@@ -403,10 +392,7 @@ resource "aws_cloudfront_distribution" "distribution" {
 
     response_headers_policy_id = local.cloudfront_response_headers_policy_id
     cache_policy_id            = local.cloudfront_cache_policy_id
-    origin_request_policy_id = try(
-      data.aws_cloudfront_origin_request_policy.origin_request_policy[0].id,
-      aws_cloudfront_origin_request_policy.origin_request_policy[0].id
-    )
+    origin_request_policy_id   = local.cloudfront_origin_request_policy_id
 
     compress               = true
     viewer_protocol_policy = "redirect-to-https"


### PR DESCRIPTION
…haviours.

<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Fixes a blocking CloudFront restriction on default managed response header policy. 

## Context

AWS CloudFront has started throwing the following error: 

InvalidArgument: The parameter Origin S3 Origins can only use the following managed request policies: CORS-CustomOrigin, CORS-S3Origin, UserAgentRefererHeaders.

This change fixes that by setting the default origin request policy to be CORS-S3Origin. 

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
