### PR TITLE
Fixing cloudfront_origin_request_policy_id and cloudfront_s3_origin_r…

### DIFF
--- a/modules/opennext-cloudfront/cloudfront.tf
+++ b/modules/opennext-cloudfront/cloudfront.tf
@@ -5,8 +5,8 @@ locals {
 
   cloudfront_cache_policy_id             = var.custom_cache_policy == null ? aws_cloudfront_cache_policy.cache_policy[0].id : data.aws_cloudfront_cache_policy.cache_policy[0].id
   cloudfront_response_headers_policy_id  = var.custom_response_headers_policy == null ? aws_cloudfront_response_headers_policy.response_headers_policy[0].id : data.aws_cloudfront_response_headers_policy.response_headers_policy[0].id
-  cloudfront_origin_request_policy_id    = var.origin_request_policy == null ? aws_cloudfront_origin_request_policy.origin_request_policy[0].id : data.aws_cloudfront_origin_request_policy.origin_request_policy[0].id
-  cloudfront_s3_origin_request_policy_id = var.origin_request_policy == null ? aws_cloudfront_origin_request_policy.origin_request_policy[0].id : data.aws_cloudfront_origin_request_policy.s3_origin_request_policy[0].id
+  cloudfront_origin_request_policy_id    = var.origin_request_policy == null ? data.aws_cloudfront_origin_request_policy.origin_request_policy[0].id : aws_cloudfront_origin_request_policy.origin_request_policy[0].id
+  cloudfront_s3_origin_request_policy_id = var.origin_request_policy == null ? data.aws_cloudfront_origin_request_policy.s3_origin_request_policy[0].id : aws_cloudfront_origin_request_policy.origin_request_policy[0].id
 }
 
 resource "aws_cloudfront_function" "host_header_function" {
@@ -30,7 +30,7 @@ data "aws_cloudfront_origin_request_policy" "origin_request_policy" {
 
 data "aws_cloudfront_origin_request_policy" "s3_origin_request_policy" {
   count = var.origin_request_policy == null ? 1 : 0
-  name  = "CORS-S3Origin"
+  name  = "Managed-CORS-S3Origin"
 }
 
 resource "aws_cloudfront_origin_request_policy" "origin_request_policy" {


### PR DESCRIPTION
…equest_policy_id locals, passing correct Managed-CORS-S3Origin request policy name.

<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Fixes ternary operator for selecting desired request policy for s3 and default. Also fixes data call for managed policy to include full managed policy name.

## Context

Fixes some breaking changes in previous release which was intended to fix an AWS introduced bug. 

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
